### PR TITLE
Fix - NameError: uninitialized constant Opscode::OpenSSL::SSL

### DIFF
--- a/libraries/check.rb
+++ b/libraries/check.rb
@@ -93,7 +93,7 @@ module Opscode
         begin
           api = Net::HTTP.new(API_HOST, API_PORT)
           api.use_ssl = true
-          api.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          api.verify_mode = ::OpenSSL::SSL::VERIFY_NONE
           request = Net::HTTP::Get.new("/api/#{API_VER}/checks", { 'App-Key' => new_resource.api_key })
           request.basic_auth(new_resource.username, new_resource.password)
           Chef::Log.debug("Pingdom: API connection configured as #{api.inspect}")
@@ -165,7 +165,7 @@ module Opscode
           Chef::Log.debug("Pingdom: Attempting to add check '#{name}' of type '#{type}' for host '#{host}' with parameters #{params.inspect}")
           api = Net::HTTP.new(API_HOST, API_PORT)
           api.use_ssl = true
-          api.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          api.verify_mode = ::OpenSSL::SSL::VERIFY_NONE
           form_data = { 'name' => name, 'host' => host, 'type' => type }
           validate_check_params(type, params)
           params.each do |k,v|
@@ -203,7 +203,7 @@ module Opscode
           result = false
           api = Net::HTTP.new(API_HOST, API_PORT)
           api.use_ssl = true
-          api.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          api.verify_mode = ::OpenSSL::SSL::VERIFY_NONE
           request = Net::HTTP::Delete.new("/api/#{API_VER}/checks/#{check_id}", { 'App-Key' => new_resource.api_key })
           request.basic_auth(new_resource.username, new_resource.password)
           Chef::Log.debug("Pingdom: API connection configured as #{api.inspect}")


### PR DESCRIPTION
It seems that OpenSSL was confused by being in the Opscode namespace - fixed by rootspacing

::OpenSSL::SSL
