### PR TITLE
Support for locking httparty gem version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,1 @@
+default.pingdom.version = '0.11.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,20 +1,22 @@
 # Author:: Cameron Johnston (<cameron@needle.com>)
-# 
+#
 # Copyright 2011, Needle, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-chef_gem 'httparty'
+chef_gem 'httparty' do
+  version node.pingdom.version
+end
 
 rb = ruby_block 'Enable httparty' do
   block do


### PR DESCRIPTION
This patch supports version pinning in httparty gem to don't break Chef 0.10.x installations.
