### PR TITLE
Updated README with alert policy caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Caveats
 
 * Changes in `check_params` do not modify the configuration of existing service checks.
 * One must look up contact IDs manually if setting `contactids` in `check_params`
+* Checks do not have an Alert Policy assigned by default.  To use the "Simple Up/Down Alerts", set `:use_legacy_notifications => true` in `check_params`.
 
 Future
 ======


### PR DESCRIPTION
Updated README with alert policy caveat concerning use_legacy_notifications parameter.

This is undocumented in the offical Pingdom API documentation.  It's also unclear how to assign an Alert Policy group if you want to use Incident Alerts instead of the legacy "Simple Up/Down Alerts".  I'm waiting to hear back from Pindom on this and will submit another pull request with further documentation if they have a solution.

This addresses https://github.com/cwjohnston/chef-pingdom/issues/10
