### PR TITLE
Support 'Account-Email' header for multi-user

### DIFF
--- a/libraries/client.rb
+++ b/libraries/client.rb
@@ -22,7 +22,7 @@ module Pingdom
       require 'rest-client'
       @key ||= key
       @api ||= RestClient::Resource.new(
-        'https://api.pingdom.com/api/2.0',
+        'https://api.pingdom.com/api/2.1',
         username,
         password
       )

--- a/libraries/client.rb
+++ b/libraries/client.rb
@@ -30,28 +30,29 @@ module Pingdom
     end
 
     def get(uri, options = {})
-      options.merge!({ app_key: @key })
-      @api[uri].get options, headers
+      add_creds!(options)
+      @api[uri].get options
     end
 
     def put(uri, body, options = {})
-      options.merge!({ app_key: @key })
-      @api[uri].put body, options, headers
+      add_creds!(options)
+      @api[uri].put body, options
     end
 
     def post(uri, body, options = {})
-      options.merge!({ app_key: @key })
-      @api[uri].post body, options, headers
+      add_creds!(options)
+      @api[uri].post body, options
     end
 
     def delete(uri, options = {})
-      options.merge!({ app_key: @key })
-      @api[uri].delete options, headers
+      add_creds!(options)
+      @api[uri].delete options
     end
 
     def checks(options = {})
       require 'json'
-      response = get('/checks', headers)
+      add_creds!(options)
+      response = get('/checks', options)
       if response.code == 200
         Chef::Log.info("got checks")
         data = ::JSON.parse(response)
@@ -64,8 +65,9 @@ module Pingdom
 
     private
 
-    def headers
-      { 'Account-Email' => @account_email } if @account_email
+    def add_creds!(options)
+      options.merge!({ app_key: @key })
+      options.merge!({ account_email: @account_email }) if @account_email
     end
   end
 end

--- a/providers/check.rb
+++ b/providers/check.rb
@@ -143,7 +143,8 @@ def pingdom_api
   pingdom_api ||= Pingdom::Client.new(
     new_resource.username,
     new_resource.password,
-    new_resource.api_key
+    new_resource.api_key,
+    new_resource.account_email
   )
 end
 

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -27,6 +27,7 @@ attribute :host, :kind_of => String, :required => true
 attribute :api_key, :kind_of => String, :required => true
 attribute :username, :kind_of => String, :required => true
 attribute :password, :kind_of => String, :required => true
+attribute :account_email, :kind_of => String, :required => false, :default => nil
 attribute :ignore_failure, :kind_of => [TrueClass,FalseClass], :default => false
 attribute :check_params, :kind_of => Hash, :default => {}
 attribute :id, :kind_of => [NilClass,Fixnum], :default => nil


### PR DESCRIPTION
Adds an 'account_email' attribute.

Might address https://github.com/cwjohnston/chef-pingdom/issues/8 ?

Use like:

``` ruby
    pingdom_check probename do
      api_key node[:application_geocms][:pingdom_api_key]
      username node[:application_geocms][:pingdom_username]
      password node[:application_geocms][:pingdom_password]
      account_email node[:application_geocms][:pingdom_account_email]
      host probe["host"]
      type "http"
      check_params(
        url: probe["url"],
        encryption: true,
        port: 443,
        shouldcontain: probe["shouldcontain"],
        tags: [
          "#{node[:application_geocms][:project_name]}#{node[:application_geocms][:environment]}",
          node[:application_geocms][:environment],
        ].join(",")
      )
    end
```
